### PR TITLE
chore: replace battery script + notifications

### DIFF
--- a/blocks.def.h
+++ b/blocks.def.h
@@ -3,7 +3,7 @@ static const Block blocks[] = {
 	/*Icon, Command, Update Interval, Update Signal*/
     {"cpu: ", "top -bn1 | grep 'Cpu(s)' | sed 's/.*, *\\([0-9.]*\\)%* id.*/\\1/' | awk '{print 100 - $1 \"%\"}'", 3, 0},
 	{"ram: ", "free -h | awk '/^Mem/ { print $3\"/\"$2 }' | sed s/i//g", 5, 0},
-    {"battery: ", "cat /sys/class/power_supply/BAT0/capacity | awk '{print $1 \"%\"}'", 30, 0},
+    {"battery: ", "$HOME/scripts/dwmblocks-battery", 30, 0},
 	{"", "date '+%B %d - %I:%M%P '", 60, 0},
 };
 


### PR DESCRIPTION
This PR replaces the previous battery script with [dwmblocks-battery](https://github.com/eoSalinas/scripts/blob/main/dwmblocks-battery) script.

The updated script provides:
- **Battery Percentage Recovery**: using [acpi](https://wiki.archlinux.org/title/ACPI_modules).
- **Low Battery Notifications**: It triggers notifications (using `libnotify` and `dunstify`) to alert the user when the battery level is low.

This change maintains the functionality of battery tracking while introducing improved notification support.