### PR TITLE
refactor: support `XDG` base directory for script paths

### DIFF
--- a/blocks.def.h
+++ b/blocks.def.h
@@ -3,7 +3,7 @@ static const Block blocks[] = {
 	/*Icon, Command, Update Interval, Update Signal*/
     {"cpu: ", "top -bn1 | grep 'Cpu(s)' | sed 's/.*, *\\([0-9.]*\\)%* id.*/\\1/' | awk '{print 100 - $1 \"%\"}'", 3, 0},
 	{"ram: ", "free -h | awk '/^Mem/ { print $3\"/\"$2 }' | sed s/i//g", 5, 0},
-    {"battery: ", "$HOME/scripts/dwmblocks-battery", 30, 0},
+    {"battery: ", "$XDG_CONFIG_HOME/scripts/dwmblocks-battery", 30, 0},
 	{"", "date '+%B %d - %I:%M%P '", 60, 0},
 };
 


### PR DESCRIPTION
This PR refactors **dwmblocks** to use the [XDG Base Directory](https://wiki.archlinux.org/title/XDG_Base_Directory) specification for locating script files, ensuring better compatibility with modern Linux environments.

### Changes:
- Replaced hardcoded paths (e.g., `$HOME/scripts/`) with XDG-compliant paths (e.g., `$XDG_CONFIG_HOME/scripts/`).
- Improved flexibility and compatibility with user-configured directories for configuration and scripts.

#### Additional Notes:
If you’re setting up your environment to fully use the XDG Base Directory, you might also want to ensure the XDG environment variables are configured.

For setting these up, check out the related [repository with .zprofile](https://github.com/eoSalinas/dots/blob/main/.zprofile) where these variables can be set globally.
